### PR TITLE
npmignore -> files field

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-js
-tests
-
-.eslintignore
-.eslintrc
-gulpfile.js

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "Jason Long"
   ],
   "main": "index.js",
+  "files": ["index.js", "lib/*js"],
   "scripts": {
     "lint": "node node_modules/eslint/bin/eslint.js .",
     "mocha": "node node_modules/mocha/bin/mocha tests",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "Jason Long"
   ],
   "main": "index.js",
-  "files": ["index.js", "lib/*js"],
+  "files": ["index.js", "lib/*.js"],
   "scripts": {
     "lint": "node node_modules/eslint/bin/eslint.js .",
     "mocha": "node node_modules/mocha/bin/mocha tests",


### PR DESCRIPTION
The `files` field in `package.json` acts as a whitelist and if therefore more robust than `.npmignore`.

Part of #18