### PR TITLE
package.json scripts: use executable from $PATH

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   ],
   "main": "index.js",
   "scripts": {
-    "lint": "node node_modules/eslint/bin/eslint.js .",
-    "mocha": "node node_modules/mocha/bin/mocha tests",
+    "lint": "eslint .",
+    "mocha": "mocha tests",
     "test": "npm run lint && npm run mocha"
   },
   "repository": {


### PR DESCRIPTION
More robust. Also what npm recommends.

Part of #18 