### PR TITLE
update dependencies, the second

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "devDependencies": {
     "browserify": "^13.1.1",
-    "eslint": "^0.10.0",
-    "mocha": "^2.0.1",
+    "eslint": "^3.12.1",
+    "mocha": "^3.2.0",
     "uglify-js": "^2.7.5",
     "watchify": "^3.7.0",
     "xml-parser": "^1.2.1"


### PR DESCRIPTION
I merged from my non-updated fork, so #21 got pretty messy. This is a clean one.

> Updating dependencies is great, as long as it's done carefully. I know off the top of my head, for example, that ESLint v3 is incompatible with `v0.10`. I'll welcome PRs to update dependencies as long as they address incompatibilities. (In the case of ESLint specifically, the easiest way will be to extend `@btmills/eslint-config-btmills@beta`, which will avoid having to create a whole new config.)

– https://github.com/btmills/geopattern/pull/18#issuecomment-265827575

I just tested using `npm test` and it still seems to work. Don't you think that's sufficient. Am I missing something?

Part of #18